### PR TITLE
New warp points for Vanilla, SDVE and RSV

### DIFF
--- a/assets/warps.json
+++ b/assets/warps.json
@@ -1,0 +1,444 @@
+/*
+    **Below is the instructions given by the original modder.**
+
+    ### Warps
+    The `Warps` field defines the warps shown in the menu. The order they're listed in doesn't
+    matter; they'll be sorted alphabetically by section and display name.
+
+    Warps are grouped by the section under which to list the warp in the menu. This can match a
+    translation ID in the i18n files, else it'll be shown as-is. See also section order below.
+
+    Each warp has four main fields:
+
+      - `DisplayText`
+        The text to show in the menu. This can match a translation ID in the i18n files, else it'll
+        be shown as-is.
+
+      - `Location`
+        The internal name of the target location (not the translated name). You can use the [Debug
+        Mode](https://www.nexusmods.com/stardewvalley/mods/679) mod to see location names in-game.
+
+      - `Tile`
+        The target tile coordinate. You can use the [Debug Mode](https://www.nexusmods.com/stardewvalley/mods/679)
+        mod to see tile coordinates in-game.
+
+      - `Order`
+        The relative order in which to list it in the warp menu (default 0). Lower values are
+        listed first. Warps with the same order are sorted alphabetically.
+
+      - `Condition`
+        A game state query which indicates whether the warp should be visible, or omit if it should
+        always be visible.
+
+
+    ### Section order
+    Warps are grouped into UI sections for easier navigation. The `SectionOrder` field lists
+    sections that should be listed at the top in the listed order. Any other sections will be
+    listed alphabetically after these sections.
+
+*/
+{
+  "SectionOrder": [
+    "warp-section.main",
+    "warp-section.town",
+    "warp-section.forest",
+    "warp-section.mountain",
+    "warp-section.beach",
+    "warp-section.desert",
+    "warp-section.island",
+    "warp-section.ridgeside-village",
+    "warp-section.ridgeside-surroundings",
+    "warp-section.galdora"
+  ],
+
+  "Warps": {
+    "warp-section.main": [
+      {
+        "DisplayText": "warp.farm",
+        "Location": "Farm",
+        "Tile": "0, 0", // Farm (0, 0) will be replaced with the tile in front of their home door
+        "Order": -1
+      },
+      {
+        "DisplayText": "warp.pierre-shop",
+        "Location": "Town",
+        "Tile": "43, 57"
+      },
+      {
+        "DisplayText": "warp.carpenter",
+        "Location": "Mountain",
+        "Tile": "12, 26"
+      },
+      {
+        "DisplayText": "warp.mines",
+        "Location": "Mine",
+        "Tile": "13, 10"
+      },
+      {
+        "DisplayText": "warp.blacksmith",
+        "Location": "Town",
+        "Tile": "94, 82"
+      },
+      {
+        "DisplayText": "warp.willy-shop",
+        "Location": "Beach",
+        "Tile": "30, 34"
+      },
+      {
+        "DisplayText": "warp.community-center",
+        "Location": "Town",
+        "Tile": "52, 20",
+        "Condition": "!IS_JOJA_MART_COMPLETE"
+      },
+      {
+        "DisplayText": "warp.hike-trail",
+        "Location": "Custom_Ridgeside_RSVTheHike",
+        "Tile": "38, 27"
+      },
+      {
+        "DisplayText": "warp.ridgeside-plaza",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "114, 45"
+      },
+      {
+        "DisplayText": "warp.foraging-forest",
+        "Location": "Custom_ForestWest",
+        "Tile": "152,25"
+      }
+    ],
+    "warp-section.town": [
+      {
+        "DisplayText": "warp.jojamart",
+        "Location": "Town",
+        "Tile": "95, 51",
+        "Condition": "!IS_COMMUNITY_CENTER_COMPLETE"
+      },
+      {
+        "DisplayText": "warp.movie-theater",
+        "Location": "Town",
+        "Tile": "95, 51",
+        "Condition": "PLAYER_HAS_MAIL Host ccMovieTheater, !PLAYER_HAS_MAIL Host ccMovieTheaterJoja"
+      },
+      {
+        "Id": "movie-theater-joja",
+        "DisplayText": "warp.movie-theater",
+        "Location": "Town",
+        "Tile": "52, 20",
+        "Condition": "PLAYER_HAS_MAIL Host ccMovieTheater, PLAYER_HAS_MAIL Host ccMovieTheaterJoja"
+      },
+      {
+        "DisplayText": "warp.museum",
+        "Location": "Town",
+        "Tile": "101, 90"
+      },
+      {
+        "DisplayText": "warp.saloon",
+        "Location": "Town",
+        "Tile": "45, 71"
+      },
+      {
+        "DisplayText": "warp.sewer",
+        "Location": "Sewer",
+        "Tile": "16, 21"
+      },
+      {
+        "DisplayText": "warp.clinic",
+        "Location": "Town",
+        "Tile": "36, 56"
+      },
+      {
+        "DisplayText": "warp.lewis",
+        "Location": "Town",
+        "Tile": "58, 86"
+      },
+      {
+        "DisplayText": "warp.garden",
+        "Location": "Town",
+        "Tile": "112, 93"
+      },
+      {
+        "DisplayText": "warp.shearwater-bridge",
+        "Location": "Custom_ShearwaterBridge",
+        "Tile": "30, 20"
+      }
+    ],
+    "warp-section.forest": [
+      {
+        "DisplayText": "warp.hats",
+        "Location": "Forest",
+        "Tile": "34, 96"
+      },
+      {
+        "DisplayText": "warp.ranch",
+        "Location": "Forest",
+        "Tile": "90, 16"
+      },
+      {
+        "DisplayText": "warp.secret-woods",
+        "Location": "Woods",
+        "Tile": "67, 5"
+      },
+      {
+        "DisplayText": "warp.wizard-tower",
+        "Location": "Forest",
+        "Tile": "9, 21"
+      },
+      {
+        "DisplayText": "warp.mastery-cave",
+        "Location": "MasteryCave",
+        "Tile": "7, 10"
+      },
+      {
+        "DisplayText": "warp.travelling-merchant",
+        "Location": "Forest",
+        "Tile": "27, 13"
+      },
+      {
+        "DisplayText": "warp.andy",
+        "Location": "Forest",
+        "Tile": "57, 70"
+      },
+      {
+        "DisplayText": "warp.apples",
+        "Location": "Custom_ApplesRoom",
+        "Tile": "14, 5"
+      },
+      {
+        "DisplayText": "warp.bear-cave",
+        "Location": "Custom_forestwest",
+        "Tile": "10, 6"
+      },
+      {
+        "DisplayText": "warp.junimo-woods",
+        "Location": "Custom_JunimoWoods",
+        "Tile": "37, 3"
+      },
+      {
+        "DisplayText": "warp.junimo-village",
+        "Location": "Custom_JunimoWoods",
+        "Tile": "34, 96"
+      },
+      {
+        "DisplayText": "warp.sprite",
+        "Location": "Custom_SpriteSpring2",
+        "Tile": "16, 23"
+      },
+      {
+        "DisplayText": "warp.aurora-vineyard",
+        "Location": "Custom_ForestWest",
+        "Tile": "58, 18"
+      },
+      {
+        "DisplayText": "warp.sophia",
+        "Location": "Custom_BlueMoonVineyard",
+        "Tile": "28, 32"
+      }
+    ],
+    "warp-section.mountain": [
+      {
+        "DisplayText": "warp.adventurers-guild",
+        "Location": "Mountain",
+        "Tile": "76, 9"
+      },
+      {
+        "DisplayText": "warp.bathhouse",
+        "Location": "Railroad",
+        "Tile": "10, 57"
+      },
+      {
+        "DisplayText": "warp.mutant-bug-lair",
+        "Location": "Bugland",
+        "Tile": "14, 52"
+      },
+      {
+        "DisplayText": "warp.quarry",
+        "Location": "Mountain",
+        "Tile": "127, 12"
+      },
+      {
+        "DisplayText": "warp.witch-swamp",
+        "Location": "WitchSwamp",
+        "Tile": "20, 23"
+      },
+      {
+        "DisplayText": "warp.summit",
+        "Location": "Summit",
+        "Tile": "11, 29"
+      },
+      {
+        "DisplayText": "warp.highlands",
+        "Location": "Custom_Highlands",
+        "Tile": "129, 113"
+      },
+      {
+        "DisplayText": "warp.highlands-cavern",
+        "Location": "Custom_HighlandsCavern",
+        "Tile": "120, 145"
+      }
+    ],
+    "warp-section.beach": [
+      {
+        "DisplayText": "warp.tide-pools",
+        "Location": "Beach",
+        "Tile": "87, 26"
+      }
+    ],
+    "warp-section.desert": [
+      {
+        "DisplayText": "warp.casino",
+        "Location": "Club",
+        "Tile": "8, 11",
+        "Condition": "PLAYER_HAS_MAIL Current HasClubCard"
+      },
+      {
+        "DisplayText": "warp.sandy-shop",
+        "Location": "Desert",
+        "Tile": "20, 15"
+      },
+      {
+        "DisplayText": "warp.skull-cavern",
+        "Location": "SkullCave",
+        "Tile": "3, 4"
+      }
+    ],
+    "warp-section.ridgeside-village": [
+      {
+        "DisplayText": "warp.log-cabin-hotel",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "114, 24"
+      },
+      {
+        "DisplayText": "warp.blooming-hill-farm",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "22, 23"
+      },
+      {
+        "DisplayText": "warp.pikas",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "97, 42"
+      },
+      {
+        "DisplayText": "warp.nightingale-orchard",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "19, 101"
+      },
+      {
+        "DisplayText": "warp.water-research",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "98, 111"
+      },
+      {
+        "DisplayText": "warp.lola-shed",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "7, 50"
+      },
+      {
+        "DisplayText": "warp.ridgeside-clinic",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "135, 37"
+      },
+      {
+        "DisplayText": "warp.ridgeside-greenhouse",
+        "Location": "Custom_Ridgeside_RidgesideVillage",
+        "Tile": "96, 75"
+      }
+    ],
+    "warp-section.ridgeside-surroundings": [
+      {
+        "DisplayText": "warp.cable-car",
+        "Location": "Custom_Ridgeside_RSVCableCar",
+        "Tile": "20, 13"
+      },
+      {
+        "DisplayText": "warp.cliff",
+        "Location": "Custom_Ridgeside_RSVCliff",
+        "Tile": "39, 24"
+      },
+      {
+        "DisplayText": "warp.ninja-house",
+        "Location": "Custom_Ridgeside_Ridge",
+        "Tile": "89, 23"
+      },
+      {
+        "DisplayText": "warp.ridge",
+        "Location": "Custom_Ridgeside_Ridge",
+        "Tile": "50, 30"
+      },
+      {
+        "DisplayText": "warp.ridge-forest",
+        "Location": "Custom_Ridgeside_RidgeForest",
+        "Tile": "80, 132"
+      },
+      {
+        "DisplayText": "warp.ridge-falls",
+        "Location": "Custom_Ridgeside_RidgeFalls",
+        "Tile": "39, 23"
+      },
+      {
+        "DisplayText": "warp.spirit-realm",
+        "Location": "Custom_Ridgeside_RSVSpiritRealm",
+        "Tile": "48, 80"
+      },
+      {
+        "DisplayText": "warp.summit-farm",
+        "Location": "Custom_Ridgeside_SummitFarm",
+        "Tile": "18, 47"
+      }
+    ],
+    "warp-section.island": [
+      {
+        "DisplayText": "warp.island-farm",
+        "Location": "IslandWest",
+        "Tile": "77, 41",
+        "Order": -1
+      },
+      {
+        "DisplayText": "warp.dwarf-shop",
+        "Location": "VolcanoDungeon5",
+        "Tile": "36, 32"
+      },
+      {
+        "DisplayText": "warp.field-office",
+        "Location": "IslandNorth",
+        "Tile": "46, 48"
+      },
+      {
+        "DisplayText": "warp.forge",
+        "Location": "Caldera",
+        "Tile": "23, 25"
+      },
+      {
+        "DisplayText": "warp.leo-house",
+        "Location": "IslandEast",
+        "Tile": "22, 14"
+      },
+      {
+        "DisplayText": "warp.fable-reef",
+        "Location": "Custom_FableReef",
+        "Tile": "44,45"
+      }
+    ],
+    "warp-section.galdora": [
+      {
+        "DisplayText": "warp.castle-outpost",
+        "Location": "Custom_CastleVillageOutpost",
+        "Tile": "31, 28"
+      },
+      {
+        "DisplayText": "warp.crimson-badlands",
+        "Location": "Custom_CrimsonBadlands",
+        "Tile": "228, 84"
+      },
+      {
+        "DisplayText": "warp.iridium-quarry",
+        "Location": "Custom_IridiumQuarry",
+        "Tile": "68, 17"
+      },
+      {
+        "DisplayText": "warp.treasure-cave",
+        "Location": "Custom_TreasureCave",
+        "Tile": "10, 12"
+      }
+    ]
+  }
+}

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -1,0 +1,301 @@
+{
+  /*********
+   ** Main translations
+   *********/
+  // mod name shown in the menu
+  "mod-name": "CJB Cheats Menu",
+
+  // tab names
+  "tabs.player-and-tools": "Player & Tools",
+  "tabs.farm-and-fishing": "Farm & Fishing",
+  "tabs.skills": "Skills",
+  "tabs.weather": "Weather",
+  "tabs.relationships": "Relationships",
+  "tabs.warp": "Warp Locations",
+  "tabs.time": "Time",
+  "tabs.advanced": "Advanced",
+  "tabs.controls": "Controls",
+
+  /*********
+   ** Player & Tools tab
+   *********/
+  // player
+  "player.title": "Player",
+  "player.infinite-stamina": "Infinite Stamina",
+  "player.infinite-health": "Infinite Health",
+  "player.instant-cooldowns": "Instant Weapon Cooldowns",
+  "player.inventory-size": "Inventory Size",
+  "player.movement-speed": "Move Speed",
+  "player.movement-speed.default": "normal",
+  "player.one-hit-kill": "One Hit Kill",
+  "player.max-daily-luck": "Max Daily Luck",
+
+  // tools
+  "tools.title": "Tools",
+  "tools.infinite-water": "Infinite Water in Can",
+  "tools.one-hit-break": "One Hit Break",
+  "tools.harvest-with-scythe": "Harvest With Scythe",
+
+  // money
+  "add.money": "Money",
+  "add.casino-coins": "Casino Coins",
+  "add.golden-walnuts": "Golden Walnuts",
+  "add.qi-gems": "Qi Gems",
+  "add.amount-gold": "Add {{amount}}g",
+  "add.amount-other": "Add {{amount}}",
+
+  /*********
+   ** Farm & Fishing tab
+   *********/
+  // farm
+  "farm.title": "Farm",
+  "farm.auto-water": "Auto-Water Crops",
+  "farm.durable-fences": "Durable Fences",
+  "farm.instant-build": "Instant Build",
+  "farm.auto-feed-animals": "Auto-Feed Animals",
+  "farm.auto-pet-animals": "Auto-Pet Animals",
+  "farm.auto-pet-pets": "Auto-Pet Pets",
+  "farm.infinite-hay": "Infinite Hay",
+
+  // fishing
+  "fishing.title": "Fishing",
+  "fishing.instant-catch": "Instant Catch",
+  "fishing.instant-bite": "Instant Bite",
+  "fishing.always-throw-max-distance": "Always Throw Max Distance",
+  "fishing.always-treasure": "Always Treasure",
+  "fishing.durable-tackles": "Durable Tackles",
+
+  // fast machines
+  "fast-machines.title": "Fast Machine Processing",
+  "fast-machines.fruit-trees": "Fruit Trees",
+  "fast-machines.ready-in-the-morning": "{{machineName}} (ready in the morning)",
+
+  /*********
+   ** Skills tab
+   *********/
+  // skills
+  "skills.title": "Skills",
+  "skills.increase-farming": "Incr. Farming Lvl: {{currentLevel}}",
+  "skills.increase-mining": "Incr. Mining Lvl: {{currentLevel}}",
+  "skills.increase-foraging": "Incr. Foraging Lvl: {{currentLevel}}",
+  "skills.increase-fishing": "Incr. Fishing Lvl: {{currentLevel}}",
+  "skills.increase-combat": "Incr. Combat Lvl: {{currentLevel}}",
+
+  // professions
+  "professions.title": "Professions",
+  "professions.combat.fighter": "Combat lvl 5 - Fighter",
+  "professions.combat.scout": "Combat lvl 5 - Scout",
+  "professions.combat.acrobat": "Combat lvl 10 - Acrobat",
+  "professions.combat.brute": "Combat lvl 10 - Brute",
+  "professions.combat.defender": "Combat lvl 10 - Defender",
+  "professions.combat.desperado": "Combat lvl 10 - Desperado",
+  "professions.farming.rancher": "Farming lvl 5 - Rancher",
+  "professions.farming.tiller": "Farming lvl 5 - Tiller",
+  "professions.farming.agriculturist": "Farming lvl 10 - Agriculturist",
+  "professions.farming.artisan": "Farming lvl 10 - Artisan",
+  "professions.farming.coopmaster": "Farming lvl 10 - Coopmaster",
+  "professions.farming.shepherd": "Farming lvl 10 - Shepherd",
+  "professions.fishing.fisher": "Fishing lvl 5 - Fisher",
+  "professions.fishing.trapper": "Fishing lvl 5 - Trapper",
+  "professions.fishing.angler": "Fishing lvl 10 - Angler",
+  "professions.fishing.luremaster": "Fishing lvl 10 - Luremaster",
+  "professions.fishing.mariner": "Fishing lvl 10 - Mariner",
+  "professions.fishing.pirate": "Fishing lvl 10 - Pirate",
+  "professions.foraging.forester": "Foraging lvl 5 - Forester",
+  "professions.foraging.gatherer": "Foraging lvl 5 - Gatherer",
+  "professions.foraging.botanist": "Foraging lvl 10 - Botanist",
+  "professions.foraging.lumberjack": "Foraging lvl 10 - Lumberjack",
+  "professions.foraging.tapper": "Foraging lvl 10 - Tapper",
+  "professions.foraging.tracker": "Foraging lvl 10 - Tracker",
+  "professions.mining.geologist": "Mining lvl 5 - Geologist",
+  "professions.mining.miner": "Mining lvl 5 - Miner",
+  "professions.mining.blacksmith": "Mining lvl 10 - Blacksmith",
+  "professions.mining.excavator": "Mining lvl 10 - Excavator",
+  "professions.mining.gemologist": "Mining lvl 10 - Gemologist",
+  "professions.mining.prospector": "Mining lvl 10 - Prospector",
+
+  /*********
+   ** Weather tab
+   *********/
+  "weather.title": "Weather Tomorrow",
+  "weather.current": "Current",
+  "weather.explanation": "Click a button below to set the weather for tomorrow (and only tomorrow). This tab has zero effect on weather otherwise.",
+  "weather.sunny": "Sunny",
+  "weather.raining": "Raining",
+  "weather.lightning": "Lightning",
+  "weather.snowing": "Snowing",
+
+  /*********
+   ** Relationships tab
+   *********/
+  "relationships.title": "Relationships",
+  "relationships.give-gifts-anytime": "Give Gifts Anytime",
+  "relationships.no-decay": "No Friendship Decay",
+  "relationships.friends": "Friends",
+
+  /*********
+   ** Warps tab
+   *********/
+  "warp.customized-warning": "These warps were edited by your mods. Please report warp issues to the mods which added them if applicable.",
+
+  // favourites
+  "warp-section.main": "Favourites",
+  "warp.farm": "Farm",
+  "warp.pierre-shop": "Pierre's Shop",
+  "warp.carpenter": "Robin's Carpentry Shop",
+  "warp.mines": "Mines",
+  "warp.blacksmith": "Clint's Blacksmithing",
+  "warp.willy-shop": "Willy's Shop",
+  "warp.community-center": "Community Center",
+  "warp.hike-trail": "Hike Trail",
+  "warp.ridgeside-plaza": "Ridgeside Plaza",
+  "warp.foraging-forest": "Foraging Forest",
+
+  // town
+  "warp-section.town": "Town",
+  "warp.jojamart": "JojaMart",
+  "warp.movie-theater": "Movie Theater",
+  "warp.museum": "Museum",
+  "warp.saloon": "Stardrop Saloon",
+  "warp.sewer": "Sewers",
+  "warp.clinic": "Harvey's Clinic",
+  "warp.lewis": "Mayor's House",
+  "warp.garden": "Garden",
+  "warp.shearwater-bridge": "Shearwater Bridge",
+
+  // forest
+  "warp-section.forest": "Forest",
+  "warp.hats": "Hats",
+  "warp.mastery-cave": "Mastery Cave",
+  "warp.ranch": "Marnie's Ranch",
+  "warp.secret-woods": "Secret Woods",
+  "warp.wizard-tower": "Wizard Tower",
+  "warp.travelling-merchant": "Travelling Merchant",
+  "warp.andy": "Andy's Farm",
+  "warp.apples": "Apples' Room",
+  "warp.bear-cave": "Bear's Cave",
+  "warp.junimo-woods": "Junimo Woods",
+  "warp.junimo-village": "Junimo Village",
+  "warp.sprite": "Sprite Spring",
+  "warp.aurora-vineyard": "Aurora Vineyard",
+  "warp.sophia": "Sophia's Vineyard",
+
+  // mountain
+  "warp.adventurers-guild": "Adventurer's Guild",
+  "warp-section.mountain": "Mountain",
+  "warp.bathhouse": "Bathhouse",
+  "warp.mutant-bug-lair": "Mutant Bug Lair",
+  "warp.quarry": "Quarry",
+  "warp.witch-swamp": "Witch's Swamp",
+  "warp.summit": "Summit",
+  "warp.highlands": "Highlands",
+  "warp.highlands-cavern": "Highlands Cavern",
+
+  // beach
+  "warp-section.beach": "Beach",
+  "warp.tide-pools": "Tide Pools",
+
+  // desert
+  "warp-section.desert": "Desert",
+  "warp.casino": "Casino",
+  "warp.sandy-shop": "Sandy's Shop",
+  "warp.skull-cavern": "Skull Cavern",
+
+  // ridgeside village
+  "warp-section.ridgeside-village": "Ridgeside Village",
+  "warp.log-cabin-hotel": "Log Cabin Hotel",
+  "warp.blooming-hill-farm": "Blooming Hill Farm",
+  "warp.pikas": "Pika's Restaurant",
+  "warp.nightingale-orchard": "Nightingale Orchard",
+  "warp.water-research": "Water Research Facility",
+  "warp.lola-shed": "Lola's Shed",
+  "warp.ridgeside-clinic": "Ridgeside Clinic",
+  "warp.ridgeside-greenhouse": "Community Greenhouse",
+
+  // ridgeside surroundings
+  "warp-section.ridgeside-surroundings": "Ridgeside Surroundings",
+  "warp.cable-car": "Cable Car",
+  "warp.cliff": "Cliff",
+  "warp.ninja-house": "Ninja House",
+  "warp.ridge": "Ridge",
+  "warp.ridge-forest": "Ridge Forest",
+  "warp.ridge-falls": "Ridge Falls",
+  "warp.spirit-realm": "Spirit Realm",
+  "warp.summit-farm": "Summit Farm",
+
+  // island
+  "warp-section.island": "Ginger Island",
+  "warp.forge": "Forge",
+  "warp.island-farm": "Island Farm",
+  "warp.dwarf-shop": "Volcano Dwarf Shop",
+  "warp.field-office": "Field Office",
+  "warp.leo-house": "Leo's House",
+  "warp.fable-reef": "Fable Reef",
+
+  // galdora
+  "warp-section.galdora": "Galdora",
+  "warp.castle-outpost": "Castle Village Outpost",
+  "warp.crimson-badlands": "Crimson Badlands",
+  "warp.iridium-quarry": "Iridium Quarry",
+  "warp.treasure-cave": "Crimson Badlands Treasure Cave",
+
+  /*********
+   ** Time tab
+   *********/
+  // time
+  "time.title": "Time",
+  "time.freeze-inside": "Freeze Time Inside",
+  "time.freeze-caves": "Freeze Time In Caves",
+  "time.freeze-everywhere": "Freeze Time Everywhere",
+  "time.time": "Time",
+  "time.time-frozen-message": "Time Frozen",
+
+  // date
+  "date.title": "Date",
+  "date.warning": "Some things won't update until a night has passed.",
+  "date.year": "Year",
+  "date.season": "Season",
+  "date.day": "Day",
+
+  /*********
+   ** Advanced tab
+   *********/
+  "flags.warning": "Use this section at your own risk!\nThis may cause issues like skipped mail, events, or quests.",
+  "flags.quests": "Complete Quests",
+  "flags.wallet": "Wallet Items",
+  "flags.unlocked": "Unlocked Areas",
+  "flags.unlocked.guild": "Adventurer's Guild",
+  "flags.unlocked.room": "Room: {{name}}",
+  "flags.unlocked-content": "Unlocked content",
+  "flags.unlocked-content.dyes-and-tailoring": "Dyes & tailoring",
+  "flags.unlocked-content.junimo-text": "Can read Junimo text",
+  "flags.community-center": "Community Center",
+  "flags.community-center.door-unlocked": "Door Unlocked",
+  "flags.jojamart.membership": "JojaMart Membership",
+
+  /*********
+   ** Controls tab
+   *********/
+  "controls.title": "Controls",
+  "controls.android-config-note": "You can change the on-screen buttons in the config files for the CJB Cheats Menu and Virtual Keyboard mods.",
+  "controls.open-menu": "Open Menu",
+  "controls.freeze-time": "Freeze Time",
+  "controls.grow-tree": "Grow Tree",
+  "controls.grow-crops": "Grow Crops",
+  "controls.grow-radius": "Grow distance around player",
+  "controls.reset-controls": "Reset",
+  "controls.press-new-key": "Press New Key...",
+
+  /*********
+   ** Generic Mod Config Menu UI
+   *********/
+  "config.open-menu.desc": "The keybind which opens the menu (when no other menu is open).",
+  "config.freeze-time.desc": "The keybind which freezes the game clock.",
+  "config.grow-tree.desc": "The keybind held to grow trees around the player.",
+  "config.grow-crops.desc": "The keybind held to grow crops around the player.",
+
+  "config.title.other-options": "Other options",
+  "config.default-tab.name": "Default tab",
+  "config.default-tab.desc": "The tab shown by default when you open the menu.",
+  "config.other-options": "To configure cheats, press the 'open menu' key shown above in-game. Make sure you press it after loading the save, when no other menu or dialogue is open."
+}


### PR DESCRIPTION
Added all new warp points for SDV Vanilla, Expanded and Ridgeside. Didn't do a fully comprehensive list of every house or anything but there are close enough warp points. 

Categorised warp points by location:

- Favourites
- Town
- Forest
- Mountain
- Beach
- Desert
- Ridgeside Village
- Ridgeside Surroundings
- Ginger Island
- Galdora